### PR TITLE
chore: remove redundant init module

### DIFF
--- a/src/init.py
+++ b/src/init.py
@@ -1,1 +1,0 @@
-# makes src a package


### PR DESCRIPTION
## Summary
- remove placeholder src/init.py so package relies on __init__.py

## Testing
- `pre-commit run --files src/__init__.py` *(fails: command not found: pre-commit)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pdfplumber')*

------
https://chatgpt.com/codex/tasks/task_e_68b6b7460a5083258c7c880be56fe31e