### PR TITLE
chore: rely on editable install

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,17 @@ final = 100 * (0.7 * semantic_similarity + 0.3 * skills_coverage)
 1. Step 0: Repo + hygiene ✅
 2. Step 1: Walking skeleton (thin end-to-end UI) ⏳
 3. Step 2+: Vertical slices (extraction → embeddings → scoring → explainability)
+
+## Running the demo
+
+Install the project in editable mode from the repository root:
+
+```bash
+pip install -e .
+```
+
+Then launch the Streamlit app:
+
+```bash
+streamlit run app/app.py
+```

--- a/app/app.py
+++ b/app/app.py
@@ -1,18 +1,10 @@
-# make repo root importable (so `import src...` works when run via streamlit)
-import sys
 from pathlib import Path
-
 import json
-
 import streamlit as st
 
-ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
-
-from src.extract import extract_text_from_file  # noqa: E402
-from src.jds import load_jds, get_jd_by_id  # noqa: E402
-from src.score_stub import compute_stub_scores  # noqa: E402
+from src.extract import extract_text_from_file
+from src.jds import load_jds, get_jd_by_id
+from src.score_stub import compute_stub_scores
 
 st.set_page_config(page_title="Resume ↔ JD Matching Demo", layout="centered")
 


### PR DESCRIPTION
## Summary
- remove manual `sys.path` manipulation and import from installed package
- document installing package in editable mode before running Streamlit

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0)*
- `streamlit run app/app.py` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pdfplumber')*

------
https://chatgpt.com/codex/tasks/task_e_68b6baa307508325af72fc10c9402c9f